### PR TITLE
feat: persist neo4j data as volume in k8s deployment

### DIFF
--- a/tutorcoursegraph/patches/k8s-deployments
+++ b/tutorcoursegraph/patches/k8s-deployments
@@ -24,8 +24,15 @@ spec:
           {% else %}
               value: 'none'
           {% endif %}
+          volumeMounts:
+            - mountPath: /data/
+              name: data
           ports:
             - containerPort: 7474  # HTTP
             - containerPort: 7687  # Bolt
           securityContext:
             allowPrivilegeEscalation: false
+      volumes:
+        - name: data
+          persistentVolumeClaim:
+            claimName: coursegraph

--- a/tutorcoursegraph/patches/k8s-volumes
+++ b/tutorcoursegraph/patches/k8s-volumes
@@ -1,0 +1,14 @@
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: coursegraph
+  labels:
+    app.kubernetes.io/component: volume
+    app.kubernetes.io/name: coursegraph
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 5Gi


### PR DESCRIPTION
without this change, neo4j data is destroyed every time the container is destroyed.

Fixes #21 