### PR TITLE
fix: Install pip and pip-tools in upgrade script

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -6,29 +6,29 @@
 #
 appdirs==1.4.4
     # via tutor
-cachetools==5.0.0
+cachetools==5.2.0
     # via google-auth
-certifi==2021.10.8
+certifi==2022.6.15
     # via
     #   kubernetes
     #   requests
 charset-normalizer==2.0.12
     # via requests
-click==8.0.4
+click==8.1.3
     # via
     #   -r requirements/base.in
     #   tutor
-google-auth==2.6.2
+google-auth==2.8.0
     # via kubernetes
 idna==3.3
     # via requests
-jinja2==3.1.1
+jinja2==3.1.2
     # via tutor
-kubernetes==23.3.0
+kubernetes==24.2.0
     # via tutor
 markupsafe==2.1.1
     # via jinja2
-mypy==0.942
+mypy==0.961
     # via tutor
 mypy-extensions==0.4.3
     # via mypy
@@ -40,7 +40,7 @@ pyasn1==0.4.8
     #   rsa
 pyasn1-modules==0.2.8
     # via google-auth
-pycryptodome==3.14.1
+pycryptodome==3.15.0
     # via tutor
 python-dateutil==2.8.2
     # via kubernetes
@@ -48,7 +48,7 @@ pyyaml==6.0
     # via
     #   kubernetes
     #   tutor
-requests==2.27.1
+requests==2.28.0
     # via
     #   kubernetes
     #   requests-oauthlib
@@ -63,15 +63,15 @@ six==1.16.0
     #   python-dateutil
 tomli==2.0.1
     # via mypy
-tutor==13.1.8
+tutor==14.0.1
     # via -r requirements/base.in
-typing-extensions==4.1.1
+typing-extensions==4.2.0
     # via mypy
 urllib3==1.26.9
     # via
     #   kubernetes
     #   requests
-websocket-client==1.3.1
+websocket-client==1.3.3
     # via kubernetes
 
 # The following packages are considered to be unsafe in a requirements file:

--- a/requirements/common_constraints.txt
+++ b/requirements/common_constraints.txt
@@ -1,0 +1,25 @@
+# A central location for most common version constraints
+# (across edx repos) for pip-installation.
+#
+# Similar to other constraint files this file doesn't install any packages.
+# It specifies version constraints that will be applied if a package is needed.
+# When pinning something here, please provide an explanation of why it is a good
+# idea to pin this package across all edx repos, Ideally, link to other information
+# that will help people in the future to remove the pin when possible.
+# Writing an issue against the offending project and linking to it here is good.
+#
+# Note: Changes to this file will automatically be used by other repos, referencing
+#  this file from Github directly. It does not require packaging in edx-lint.
+
+
+# using LTS django version
+Django<4.0
+
+# elasticsearch>=7.14.0 includes breaking changes in it which caused issues in discovery upgrade process.
+# elastic search changelog: https://www.elastic.co/guide/en/enterprise-search/master/release-notes-7.14.0.html
+elasticsearch<7.14.0
+
+setuptools<60
+
+# django-simple-history>3.0.0 adds indexing and causes a lot of migrations to be affected
+django-simple-history==3.0.0

--- a/requirements/constraints.txt
+++ b/requirements/constraints.txt
@@ -1,0 +1,11 @@
+# Version constraints for pip-installation.
+#
+# This file doesn't install any packages. It specifies version constraints
+# that will be applied if a package is needed.
+#
+# When pinning something here, please provide an explanation of why.  Ideally,
+# link to other information that will help people in the future to remove the
+# pin when possible.  Writing an issue against the offending project and
+# linking to it here is good.
+
+-c common_constraints.txt

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -5,46 +5,44 @@
 #    make upgrade
 #
 altgraph==0.17.2
-    # via pyinstaller
+    # via
+    #   macholib
+    #   pyinstaller
 appdirs==1.4.4
     # via
     #   -r requirements/base.txt
     #   tutor
-astroid==2.11.2
+astroid==2.11.6
     # via pylint
-black==22.1.0
+black==22.3.0
     # via -r requirements/dev.in
-bleach==4.1.0
+bleach==5.0.0
     # via readme-renderer
-cachetools==5.0.0
+cachetools==5.2.0
     # via
     #   -r requirements/base.txt
     #   google-auth
-certifi==2021.10.8
+certifi==2022.6.15
     # via
     #   -r requirements/base.txt
     #   kubernetes
     #   requests
-cffi==1.15.0
-    # via cryptography
 charset-normalizer==2.0.12
     # via
     #   -r requirements/base.txt
     #   requests
-click==8.0.4
+click==8.1.3
     # via
     #   -r requirements/base.txt
     #   black
     #   tutor
-colorama==0.4.4
-    # via twine
-cryptography==36.0.2
-    # via secretstorage
-dill==0.3.4
+commonmark==0.9.1
+    # via rich
+dill==0.3.5.1
     # via pylint
 docutils==0.18.1
     # via readme-renderer
-google-auth==2.6.2
+google-auth==2.8.0
     # via
     #   -r requirements/base.txt
     #   kubernetes
@@ -52,35 +50,33 @@ idna==3.3
     # via
     #   -r requirements/base.txt
     #   requests
-importlib-metadata==4.11.3
+importlib-metadata==4.11.4
     # via
     #   keyring
     #   twine
 isort==5.10.1
     # via pylint
-jeepney==0.7.1
-    # via
-    #   keyring
-    #   secretstorage
-jinja2==3.1.1
+jinja2==3.1.2
     # via
     #   -r requirements/base.txt
     #   tutor
-keyring==23.5.0
+keyring==23.6.0
     # via twine
-kubernetes==23.3.0
+kubernetes==24.2.0
     # via
     #   -r requirements/base.txt
     #   tutor
 lazy-object-proxy==1.7.1
     # via astroid
+macholib==1.16
+    # via pyinstaller
 markupsafe==2.1.1
     # via
     #   -r requirements/base.txt
     #   jinja2
 mccabe==0.7.0
     # via pylint
-mypy==0.942
+mypy==0.961
     # via
     #   -r requirements/base.txt
     #   tutor
@@ -93,13 +89,11 @@ oauthlib==3.2.0
     # via
     #   -r requirements/base.txt
     #   requests-oauthlib
-packaging==21.3
-    # via bleach
 pathspec==0.9.0
     # via black
-pkginfo==1.8.2
+pkginfo==1.8.3
     # via twine
-platformdirs==2.5.1
+platformdirs==2.5.2
     # via
     #   black
     #   pylint
@@ -112,22 +106,20 @@ pyasn1-modules==0.2.8
     # via
     #   -r requirements/base.txt
     #   google-auth
-pycparser==2.21
-    # via cffi
-pycryptodome==3.14.1
+pycryptodome==3.15.0
     # via
     #   -r requirements/base.txt
     #   tutor
-pygments==2.11.2
-    # via readme-renderer
-pyinstaller==4.10
+pygments==2.12.0
+    # via
+    #   readme-renderer
+    #   rich
+pyinstaller==5.1
     # via -r requirements/dev.in
-pyinstaller-hooks-contrib==2022.3
+pyinstaller-hooks-contrib==2022.7
     # via pyinstaller
-pylint==2.13.2
+pylint==2.14.3
     # via -r requirements/dev.in
-pyparsing==3.0.7
-    # via packaging
 python-dateutil==2.8.2
     # via
     #   -r requirements/base.txt
@@ -138,9 +130,9 @@ pyyaml==6.0
     #   -r requirements/dev.in
     #   kubernetes
     #   tutor
-readme-renderer==34.0
+readme-renderer==35.0
     # via twine
-requests==2.27.1
+requests==2.28.0
     # via
     #   -r requirements/base.txt
     #   kubernetes
@@ -155,12 +147,12 @@ requests-toolbelt==0.9.1
     # via twine
 rfc3986==2.0.0
     # via twine
+rich==12.4.4
+    # via twine
 rsa==4.8
     # via
     #   -r requirements/base.txt
     #   google-auth
-secretstorage==3.3.1
-    # via keyring
 six==1.16.0
     # via
     #   -r requirements/base.txt
@@ -174,23 +166,24 @@ tomli==2.0.1
     #   black
     #   mypy
     #   pylint
-tqdm==4.63.1
-    # via twine
-tutor==13.1.8
+tomlkit==0.11.0
+    # via pylint
+tutor==14.0.1
     # via -r requirements/base.txt
-twine==3.8.0
+twine==4.0.1
     # via -r requirements/dev.in
-types-pyyaml==6.0.5
+types-pyyaml==6.0.8
     # via -r requirements/dev.in
-types-setuptools==57.4.11
+types-setuptools==57.4.17
     # via -r requirements/dev.in
-typing-extensions==4.1.1
+typing-extensions==4.2.0
     # via
     #   -r requirements/base.txt
     #   astroid
     #   black
     #   mypy
     #   pylint
+    #   rich
 urllib3==1.26.9
     # via
     #   -r requirements/base.txt
@@ -199,13 +192,13 @@ urllib3==1.26.9
     #   twine
 webencodings==0.5.1
     # via bleach
-websocket-client==1.3.1
+websocket-client==1.3.3
     # via
     #   -r requirements/base.txt
     #   kubernetes
-wrapt==1.14.0
+wrapt==1.14.1
     # via astroid
-zipp==3.7.0
+zipp==3.8.0
     # via importlib-metadata
 
 # The following packages are considered to be unsafe in a requirements file:

--- a/requirements/pip-tools.in
+++ b/requirements/pip-tools.in
@@ -1,0 +1,3 @@
+-c constraints.txt
+
+pip-tools

--- a/requirements/pip-tools.txt
+++ b/requirements/pip-tools.txt
@@ -4,13 +4,17 @@
 #
 #    make upgrade
 #
+click==8.1.3
+    # via pip-tools
+pep517==0.12.0
+    # via pip-tools
+pip-tools==6.6.2
+    # via -r requirements/pip-tools.in
+tomli==2.0.1
+    # via pep517
 wheel==0.37.1
-    # via -r requirements/pip.in
+    # via pip-tools
 
 # The following packages are considered to be unsafe in a requirements file:
-pip==22.1.2
-    # via -r requirements/pip.in
-setuptools==59.8.0
-    # via
-    #   -c requirements/common_constraints.txt
-    #   -r requirements/pip.in
+# pip
+# setuptools

--- a/requirements/pip.in
+++ b/requirements/pip.in
@@ -1,12 +1,7 @@
+-c constraints.txt
+
 # Core dependencies for installing other packages
 
-# pip>=22 is incompatible with latest pip tools, raises:
-#
-#    ...
-#         assert isinstance(handler, logging.StreamHandler)
-#    AssertionError
-pip<22
-
+pip
 setuptools
 wheel
-pip-tools


### PR DESCRIPTION
Updated the upgrade target script to check the compatibility of upgraded pip and pip-tools versions. For reference, look at this https://github.com/openedx/edx-repo-health/pull/271 for new check added in edx-repo-health.