### PR TITLE
build: fix caddy installation for CI workflow

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -37,12 +37,12 @@ jobs:
         run: make test-pythonpackage
 
       - name: Install caddy for Caddyfile syntax checking
-        run: |
-          sudo apt-get install -y debian-keyring debian-archive-keyring apt-transport-https
-          curl -1sLf 'https://dl.cloudsmith.io/public/caddy/stable/gpg.key' | sudo tee /etc/apt/trusted.gpg.d/caddy-stable.asc
+        run: |        
+          sudo apt install -y debian-keyring debian-archive-keyring apt-transport-https
+          curl -1sLf 'https://dl.cloudsmith.io/public/caddy/stable/gpg.key' | sudo gpg --dearmor -o /usr/share/keyrings/caddy-stable-archive-keyring.gpg
           curl -1sLf 'https://dl.cloudsmith.io/public/caddy/stable/debian.deb.txt' | sudo tee /etc/apt/sources.list.d/caddy-stable.list
-          sudo apt-get update
-          sudo apt-get install caddy
+          sudo apt update
+          sudo apt install caddy
 
       - name: Plugin installation & rendering checks
         run: make test-install


### PR DESCRIPTION
CI was failing with:

```
  W: GPG error:
  https://dl.cloudsmith.io/public/caddy/stable/deb/debian any-version InRelease:
  The following signatures couldn't be verified because the public key is not available:
  NO_PUBKEY ABA1F9B8875A6661
  E: The repository
  'https://dl.cloudsmith.io/public/caddy/stable/deb/debian any-version InRelease'
  is not signed.
  Error: Process completed with exit code 100.
```

We update the caddyfile installation in the
test.yml workflow based on these instructions:
https://caddyserver.com/docs/install#debian-ubuntu-raspbian