### PR TITLE
fix: pypi-publish master branch sunset

### DIFF
--- a/.github/workflows/pypi-publish.yml
+++ b/.github/workflows/pypi-publish.yml
@@ -23,7 +23,7 @@ jobs:
         run: make build-pythonpackage
 
       - name: Publish to PyPI
-        uses: pypa/gh-action-pypi-publish@master
+        uses: pypa/gh-action-pypi-publish@release/v1
         with:
           user: __token__
           password: ${{ secrets.PYPI_UPLOAD_TOKEN }}


### PR DESCRIPTION
This will fix the warning of 'The master branch version has been sunset for gh-action-pypi-publisher'